### PR TITLE
Text Bugfix and Improvements

### DIFF
--- a/src/gt/feature/text/text.c
+++ b/src/gt/feature/text/text.c
@@ -12,14 +12,14 @@
 char font_slot;
 char text_cursor_x, text_cursor_y;
 char text_print_width, text_print_line_start;
-TextColor text_color;
+unsigned char text_color;
 
 void init_text() {
     text_cursor_x = 0;
     text_cursor_y = 0;
     text_print_width = 128;
     text_print_line_start = 0;
-    text_color = TextColorBlack;
+    text_color = TEXT_COLOR_BLACK;
 }
 
 void load_font(char slot) {

--- a/src/gt/feature/text/text.c
+++ b/src/gt/feature/text/text.c
@@ -39,8 +39,7 @@ void print_text(char* text) {
         text_use_alt_color = 128;
     }
     while(*text != 0) {
-        text_tmp = *text + text_use_alt_color;
-        switch(text_tmp) {
+        switch(*text) {
             case ' ':
                 text_cursor_x += TEXT_CHAR_WIDTH;
                 break;
@@ -52,6 +51,7 @@ void print_text(char* text) {
                 text_cursor_x = text_print_line_start;
                 break;
             default:
+                text_tmp = *text + text_use_alt_color;
                 if(text_cursor_x >= (text_print_width + text_print_line_start)) {
                     text_cursor_x -= text_print_width;
                     text_cursor_y += TEXT_CHAR_HEIGHT;

--- a/src/gt/feature/text/text.c
+++ b/src/gt/feature/text/text.c
@@ -12,14 +12,14 @@
 char font_slot;
 char text_cursor_x, text_cursor_y;
 char text_print_width, text_print_line_start;
-char text_use_alt_color;
+TextColor text_color;
 
 void init_text() {
     text_cursor_x = 0;
     text_cursor_y = 0;
     text_print_width = 128;
     text_print_line_start = 0;
-    text_use_alt_color = 0;
+    text_color = TextColorBlack;
 }
 
 void load_font(char slot) {
@@ -35,9 +35,6 @@ void print_text(char* text) {
     vram[WIDTH] = TEXT_CHAR_WIDTH;
     vram[HEIGHT] = TEXT_CHAR_HEIGHT;
     vram[VY] = text_cursor_y;
-    if(text_use_alt_color) {
-        text_use_alt_color = 128;
-    }
     while(*text != 0) {
         switch(*text) {
             case ' ':
@@ -51,7 +48,7 @@ void print_text(char* text) {
                 text_cursor_x = text_print_line_start;
                 break;
             default:
-                text_tmp = *text + text_use_alt_color;
+                text_tmp = *text + text_color;
                 if(text_cursor_x >= (text_print_width + text_print_line_start)) {
                     text_cursor_x -= text_print_width;
                     text_cursor_y += TEXT_CHAR_HEIGHT;

--- a/src/gt/feature/text/text.h
+++ b/src/gt/feature/text/text.h
@@ -1,6 +1,11 @@
 #ifndef TEXT_H
 #define TEXT_H
 
+typedef enum {
+  TextColorBlack = 0,
+  TextColorWhite = 128,
+} TextColor;
+
 void init_text();
 
 void load_font(char slot);
@@ -8,6 +13,6 @@ void load_font(char slot);
 void print_text(char* text);
 
 extern char text_cursor_x, text_cursor_y, text_print_width, text_print_line_start;
-extern char text_use_alt_color;
+extern TextColor text_color;
 
 #endif

--- a/src/gt/feature/text/text.h
+++ b/src/gt/feature/text/text.h
@@ -1,10 +1,8 @@
 #ifndef TEXT_H
 #define TEXT_H
 
-typedef enum {
-  TextColorBlack = 0,
-  TextColorWhite = 128,
-} TextColor;
+#define TEXT_COLOR_BLACK 0
+#define TEXT_COLOR_WHITE 128
 
 void init_text();
 
@@ -13,6 +11,6 @@ void load_font(char slot);
 void print_text(char* text);
 
 extern char text_cursor_x, text_cursor_y, text_print_width, text_print_line_start;
-extern TextColor text_color;
+extern unsigned char text_color;
 
 #endif


### PR DESCRIPTION
Two things related to text in this pr:

- Due to `text_use_alt_color` being added to `*text` before checking for control characters, control characters were being ignored if using white text
- Simplified the API for controlling text color with a text color enum.  As an added bonus, this allows us to avoid some work related to checking if `text_use_alt_color` is set but not set to 128.

Edit: replaced enums with `#define`s, as enums are 16 bit in cc65 :/