### PR TITLE
Remember to pop sfx bank

### DIFF
--- a/src/gt/music.c
+++ b/src/gt/music.c
@@ -216,6 +216,8 @@ void tick_music() {
             set_audio_param(PITCH_MSB + op, pitch_table[a]);
             set_audio_param(PITCH_LSB + op, pitch_table[a+1]);
             ++op;
+
+            pop_rom_bank();
         } else {
             op = sound_effect_channel << 2;
             set_audio_param(AMPLITUDE+(op+3), sine_offset);


### PR DESCRIPTION
This just ends a corresponding `pop_rom_bank()` to correspond to the `change_rom_bank` at the start of the sfx playing code