### PR TITLE
Sfx micro optimizations

### DIFF
--- a/src/gt/music.c
+++ b/src/gt/music.c
@@ -188,34 +188,39 @@ void unpause_music() {
 }
 
 void tick_music() {
-    static unsigned char n, noteMask, a, op, ch;
+    static unsigned char n, noteMask, ch;
+    register unsigned char a, op;
 
      if(sound_effect_length) {
         sound_effect_length--;
         if(sound_effect_length) {
             change_rom_bank(sound_effect_bank);
+
             op = sound_effect_channel << 2;
-            set_audio_param(AMPLITUDE+(op++), *(sound_effect_ptr++) + sine_offset);
-            set_audio_param(AMPLITUDE+(op++),*(sound_effect_ptr++) + sine_offset);
-            set_audio_param(AMPLITUDE+(op++), *(sound_effect_ptr++) + sine_offset);
-            set_audio_param(AMPLITUDE+(op++), *(sound_effect_ptr++) + sine_offset);
-            op -= 4;
-            a = *(sound_effect_ptr++) << 1;
+            set_audio_param(AMPLITUDE + op, *(sound_effect_ptr+0) + sine_offset);
+            a = *(sound_effect_ptr+4) << 1;
             set_audio_param(PITCH_MSB + op, pitch_table[a]);
             set_audio_param(PITCH_LSB + op, pitch_table[a+1]);
+
             ++op;
-            a = *(sound_effect_ptr++) << 1;
+            set_audio_param(AMPLITUDE + op, *(sound_effect_ptr+1) + sine_offset);
+            a = *(sound_effect_ptr+5) << 1;
             set_audio_param(PITCH_MSB + op, pitch_table[a]);
             set_audio_param(PITCH_LSB + op, pitch_table[a+1]);
+
             ++op;
-            a = *(sound_effect_ptr++) << 1;
+            set_audio_param(AMPLITUDE + op, *(sound_effect_ptr+2) + sine_offset);
+            a = *(sound_effect_ptr+6) << 1;
             set_audio_param(PITCH_MSB + op, pitch_table[a]);
             set_audio_param(PITCH_LSB + op, pitch_table[a+1]);
+
             ++op;
-            a = *(sound_effect_ptr++) << 1;
+            set_audio_param(AMPLITUDE + op, *(sound_effect_ptr+3) + sine_offset);
+            a = *(sound_effect_ptr+7) << 1;
             set_audio_param(PITCH_MSB + op, pitch_table[a]);
             set_audio_param(PITCH_LSB + op, pitch_table[a+1]);
-            ++op;
+
+            sound_effect_ptr += 8;
 
             pop_rom_bank();
         } else {

--- a/src/gt/music.c
+++ b/src/gt/music.c
@@ -216,6 +216,8 @@ void tick_music() {
             set_audio_param(PITCH_MSB + op, pitch_table[a]);
             set_audio_param(PITCH_LSB + op, pitch_table[a+1]);
             ++op;
+
+            pop_rom_bank();
         } else {
             op = sound_effect_channel << 2;
             set_audio_param(AMPLITUDE+(op+3), sine_offset);


### PR DESCRIPTION
Micro optimizations in pushing sfx data to the audio processor.  Meant to be merged after #16 

I was checking out the code that pushed sfx data from the main processor to the audio processor.  I noticed that there might me some room for optimization and kinda got carried away...

The basic idea is that rather than setting all the amplitudes first and then all of the pitches, the amplitudes and pitches are grouped to minimize required changes to `op`.  Unfortunately, this does mean that `sfx_effect_ptr` is a bit messy as instead of accessing entries in the order `0, 1, 2, ...` we're accessing them in the order `0, 4, 1, 5, 2, 6, 3, 7`.

`op` and `a` have also been marked `register`.  This required unmarking them as `static`, which shouldn't have any effect on this function as they are always initialized so they shouldn't be holding any static value.  If I'm missing something, feel free to let me know

Moving sfx data took 1338 cycles before these optimizations, 1224 after.  Difference of 114 cycles