### PR TITLE
save_write: Prefer void *

### DIFF
--- a/src/gt/persist.c
+++ b/src/gt/persist.c
@@ -59,7 +59,7 @@ void lock_bypass() {
 
 //src assumed not Flash ROM
 //dest assumned to be in Flash ROM
-void save_write(char* src, char* dest, char len) {
+void save_write(void *src, void *dest, char len) {
     if(executing_from_rom()) {
         while(1) {}
     }
@@ -71,8 +71,8 @@ void save_write(char* src, char* dest, char len) {
     unlock_bypass();
     while(k) {
         *((unsigned char*) 0x8000) = 0xA0;
-        dest[i] = src[i];
-        while(dest[i] != src[i]) {
+        ((char *)dest)[i] = ((char *)src)[i];
+        while(((char *) dest)[i] != ((char *) src)[i]) {
             
         }
         i++;

--- a/src/gt/persist.h
+++ b/src/gt/persist.h
@@ -1,4 +1,4 @@
 #define SAVE_BANK_NUM 0xFE
 
 void clear_save_sector();
-void save_write(char* src, char* dest, char len);
+void save_write(void *src, void *dest, char len);


### PR DESCRIPTION
Prefer the use of `void *` to `char *` in `save_write` (a la `memcpy`)

This is a bit silly since the `void *`s are just cast to `char *` in the body of the function, but this change gets rid of some annoying compiler warnings when using `save_write` normally.