### PR TITLE
paddle feature adds

### DIFF
--- a/project.json
+++ b/project.json
@@ -6,6 +6,7 @@
         "PERSIST",
         "RANDOM",
         "TEXT",
-        "DRAWQUEUE"
+        "DRAWQUEUE",
+        "PADDLEINPUT"
     ]
 }

--- a/src/gt/feature/paddleInput/paddleInput.c
+++ b/src/gt/feature/paddleInput/paddleInput.c
@@ -1,0 +1,48 @@
+#include "../../input.h"
+#include "paddleInput.h"
+#include "../../../gen/modules_enabled.h"
+#include "../../gametank.h"
+
+#ifdef ENABLE_MODULE_PADDLEINPUT
+
+#pragma optimize (push, off)
+void update_paddle_inputs(){
+    char inputsA, inputsB;
+    inputsA = *gamepad_2;
+    inputsA = *gamepad_1;
+    inputsB = *gamepad_1;
+
+    player1_old_buttons = player1_buttons;
+    player1_buttons = ~((((int) inputsB) << 8) | inputsA);
+    player1_buttons &= INPUT_MASK_PADDLE_ALL_KEYS;
+    player1_new_buttons = player1_buttons & ~player1_old_buttons;
+
+    inputsA = *gamepad_2;
+    inputsB = *gamepad_2;
+    player2_old_buttons = player2_buttons;
+    player2_buttons = ~((((int) inputsB) << 8) | inputsA);
+    player2_buttons &= INPUT_MASK_PADDLE_ALL_KEYS;
+    player2_new_buttons = player2_buttons & ~player2_old_buttons;
+}
+#pragma optimize (pop)
+
+unsigned char get_paddle_rotation(char port) {
+    unsigned char result = 0;
+    int _player_buttons;
+
+    if (port==1) _player_buttons = player2_buttons;
+    else _player_buttons = player1_buttons;//fallback to player 1 at port 0
+
+    if (_player_buttons & INPUT_MASK_PADDLE_UP) result |= (1 << 0);
+    if (_player_buttons & INPUT_MASK_PADDLE_DOWN) result |= (1 << 1);
+    if (_player_buttons & INPUT_MASK_PADDLE_LEFT) result |= (1 << 2);
+    if (_player_buttons & INPUT_MASK_PADDLE_RIGHT) result |= (1 << 3);
+    if (_player_buttons & INPUT_MASK_PADDLE_X) result |= (1 << 4);
+    if (_player_buttons & INPUT_MASK_PADDLE_Y) result |= (1 << 5);
+    if (_player_buttons & INPUT_MASK_PADDLE_Z) result |= (1 << 6);
+    if (_player_buttons & INPUT_MASK_PADDLE_MODE) result |= (1 << 7);
+
+    return ~result;//invert result
+}
+
+#endif

--- a/src/gt/feature/paddleInput/paddleInput.h
+++ b/src/gt/feature/paddleInput/paddleInput.h
@@ -1,0 +1,35 @@
+// This module provides an alternative to the standard update_inputs() function.
+// If ENABLE_MODULE_PADDLEINPUT is active, use update_paddle_inputs()
+// to capture extended data for paddles and touch interfaces.
+
+#ifndef PADDLEINPUT_H
+#define PADDLEINPUT_H
+
+#include "../../input.h"
+#include "../../../gen/modules_enabled.h"
+
+#ifndef ENABLE_MODULE_PADDLEINPUT
+#error "Module PADDLEINPUT included but not enabled!"
+#endif
+
+#ifdef ENABLE_MODULE_PADDLEINPUT
+
+#define INPUT_MASK_PADDLE_UP		2048    //prioritizes high, was 2056
+#define INPUT_MASK_PADDLE_DOWN		1024    //prioritizes high, was 1028 
+#define INPUT_MASK_PADDLE_LEFT		512     //high
+#define INPUT_MASK_PADDLE_RIGHT	256     //high
+#define INPUT_MASK_PADDLE_A		16      //low
+#define INPUT_MASK_PADDLE_B		4096    //high
+#define INPUT_MASK_PADDLE_C		8192    //high
+#define INPUT_MASK_PADDLE_START	32      //low
+#define INPUT_MASK_PADDLE_MODE 1           //low
+#define INPUT_MASK_PADDLE_X 2              //low
+#define INPUT_MASK_PADDLE_Y 4              //low
+#define INPUT_MASK_PADDLE_Z 8              //low
+#define INPUT_MASK_PADDLE_ALL_KEYS (INPUT_MASK_PADDLE_UP|INPUT_MASK_PADDLE_DOWN|INPUT_MASK_PADDLE_LEFT|INPUT_MASK_PADDLE_RIGHT|INPUT_MASK_PADDLE_A|INPUT_MASK_PADDLE_B|INPUT_MASK_PADDLE_C|INPUT_MASK_PADDLE_START|INPUT_MASK_PADDLE_MODE|INPUT_MASK_PADDLE_X|INPUT_MASK_PADDLE_Y|INPUT_MASK_PADDLE_Z)//add new keys
+
+void update_paddle_inputs();
+unsigned char get_paddle_rotation(char);
+
+#endif //ifdef ENABLE_MODULE_PADDLEINPUT
+#endif //ifdef PADDLEINPUT_H


### PR DESCRIPTION
This PR adds two new header files to add paddle inputs, where the developer would add:

`#include "gt/feature/paddleInput/paddleInput.h" 
`
in the place of 

`#include "gt/input.h"
`

to add extra input masks which are appropriate to paddle controllers only
These modified input masks include changes to Up and Down where

```
#define INPUT_MASK_UP		2056
#define INPUT_MASK_DOWN		1028
```

are redefined as:

```
#define INPUT_MASK_PADDLE_UP		2048    //prioritizes high, was 2056
#define INPUT_MASK_PADDLE_DOWN		1024    //prioritizes high, was 1028 
```

in order to separate the high and low states of the controller pins, giving us the extra bits needed for the digitized paddle

paddleInput also adds 4 new input masks for previously undefined input bits:
```
#define INPUT_MASK_PADDLE_MODE 1           //low
#define INPUT_MASK_PADDLE_X 2              //low
#define INPUT_MASK_PADDLE_Y 4              //low
#define INPUT_MASK_PADDLE_Z 8              //low
```

paddleInput also adds an updated function to updateInputs:

`void update_paddle_inputs()
`

and a new function to get the paddle rotation represented as a byte where 0 represents the paddle rotated left and 255 represents the paddle rotated to the right

`unsigned char get_paddle_rotation(char port)
`
